### PR TITLE
Fix app crash on empty year field.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,11 @@ import ResultsText from './components/result/ResultsText'
 
 const defaultStrategy: Strategy = {
   initialDeposit: 0, // in cents
-  regularDeposit: 0, // in cents
-  depositFrequency: "Monthly",
-  compoundFrequency: "Monthly",
+  regularDeposit: 2000, // in cents
+  depositFrequency: "Annually",
+  compoundFrequency: "Annually",
   numberOfYears: 10,
-  annualInterestRate: 5
+  annualInterestRate: 500
 }
 
 const App = () => {
@@ -83,14 +83,14 @@ const App = () => {
       <div className="row justify-content-center">
         <div className="col-12">
             <h2>Results</h2>
-            <ResultChart data={result} initialDeposit={strategy.initialDeposit} />
+            {(strategy.numberOfYears > 0) ? <ResultChart data={result} initialDeposit={strategy.initialDeposit} /> : "" }
         </div>
       </div>
 
       <div className="row justify-content-center">
         <div className="col-12">
             <h3>Your strategy</h3>
-            <ResultsText data={result} initialDeposit={strategy.initialDeposit} />
+            {(strategy.numberOfYears > 0) ? <ResultsText data={result} initialDeposit={strategy.initialDeposit} /> : "" }
         </div>
       </div>
       <hr />

--- a/src/services/CompoundInterest.tsx
+++ b/src/services/CompoundInterest.tsx
@@ -36,6 +36,9 @@ const frequencyPerYear = (frequency: Frequency): number => {
 
 export const calculateCompoundInterest = (strategy: Strategy) => {
 
+  // Guard: Check number of years is more than 0
+  if (strategy.numberOfYears < 1) return
+
   // Definitions
   const initialDeposit = strategy.initialDeposit/100
   const regularDeposit = strategy.regularDeposit/100


### PR DESCRIPTION
The app was crashing when users deleted the input in the year field. I fixed this by:
- Not displaying the graphs if there was 0 years.
- Adding a guard to prevent compound interest calculation if there are 0 years.

History:
> - App.tsx: Only render results if there are more than 0 years.
> - Guard to prevent crash if less than 1 year.
> - Do not display graph is there are 0 years.
> - Fix defaults