### PR TITLE
Changed Form Input Type To Number

### DIFF
--- a/src/components/calculator/TextInput.tsx
+++ b/src/components/calculator/TextInput.tsx
@@ -19,7 +19,7 @@ const TextInput: React.FC<Props> = ({label, name, prepend, append, onSubmit, val
       <div className="input-group mb-3">
         {prepend && <span className="input-group-text">{prepend}</span>}
         <input
-          type="text"
+          type="number"
           name={name}
           className="form-control"
           aria-label="{label}"


### PR DESCRIPTION
When using the site on mobile: it is difficult to use the input fields, as they natively display for text input.
This defaults to expecting a qwerty keyboard input, and expects the field as a text based string.
Changing the input type to "number" prompts mobile displays to default to a number pad instead of letters
`<input type="text">` -> From This
`<input type="number">` -> To This

### Mobile Screenshot Before:
![pre-1](https://user-images.githubusercontent.com/9586453/133868389-52ce9dd9-d256-4b06-a3c5-a10a5735334e.png)
![pre-2](https://user-images.githubusercontent.com/9586453/133868388-944737b0-bd65-47cd-9bf5-7af3cf9955d3.png)



### Mobile Screenshot After:
![post-1](https://user-images.githubusercontent.com/9586453/133868399-d21edc41-07d5-437f-9014-6b2b8cf6e376.png)
![post-2](https://user-images.githubusercontent.com/9586453/133868398-b74478cd-c08c-41b6-ba33-f470601f4dc4.png)

